### PR TITLE
Resolved incorrect doi bug

### DIFF
--- a/orcid.js
+++ b/orcid.js
@@ -46,7 +46,12 @@ function createORCIDProfile(orcidID, elementID) {
 
                         //DOI REFERENCE
                         if (data.group[i]["external-ids"]["external-id"]["length"] != 0) {
-                            var doiReference = data.group[i]["external-ids"]["external-id"]["0"]["external-id-value"];
+                            for (var j in data.group[i]["external-ids"]["external-id"]) {
+                                if (data.group[i]["external-ids"]["external-id"][j]["external-id-type"] == 'doi') {
+                                    var doiReference = data.group[i]["external-ids"]["external-id"][j]["external-id-value"];
+                                    break;
+                                }
+                            }
                         }
                         else {
                             var doiReference = "";


### PR DESCRIPTION
The original script would occasionally pull PMC links in place of doi. This change iterates external-ids to return the doi specifically.